### PR TITLE
feat: Add Makefile to project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ watch:
 	@which reflex > /dev/null || (go install github.com/cespare/reflex@latest)
 	reflex -s -r '\.go$$' make run
 
+.PHONY: test
+## test: Run all tests
+test:
+	@go test -v ./...
+
 .PHONY: help
 all: help
 ## help: show this help message

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+NAME=slick
+VERSION=0.0.1
+
+.DEFAULT_GOAL := help
+
+.PHONY: build
+## build: Compile the packages.
+build:
+	@go build -v -o bin/$(NAME) cmd/$(NAME)/main.go
+
+.PHONY: install
+## install: Install the packages.
+install: build
+	@mv bin/$(NAME) $(GOPATH)/bin/$(NAME)
+
+.PHONY: clean
+## clean: Clean projects and previous builds
+clean:
+	@rm -rf bin/*
+
+.PHONY: deps
+## deps: Download modules
+deps:
+	@go mod download
+
+.PHONY: watch
+## watch: Reload the app whenever the source changes
+watch:
+	@which reflex > /dev/null || (go install github.com/cespare/reflex@latest)
+	reflex -s -r '\.go$$' make run
+
+.PHONY: help
+all: help
+## help: show this help message
+help: Makefile
+	@echo
+	@echo " Choose a command to run:"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/ /'
+	@echo

--- a/README.md
+++ b/README.md
@@ -42,10 +42,8 @@ To start using Slick Deploy, install it right from the source:
 ```bash
 git clone https://github.com/scmmishra/slick-deploy.git
 cd slick-deploy
-go build -o slick ./cmd/slick
+make install
 ```
-
-You can now move the slick binary to a directory in your PATH to make it globally accessible.
 
 ### Usage
 


### PR DESCRIPTION
Add a makefile to the project to support the following operations:

- build
- install
- clean
- deps
- watch
- help
- test

Update the README to use the Makefile command as well and move from using `go build` to `go install` in the Makefile.