### PR TITLE
refactor: use `net.DialTimeout` instead of `Listen`

### DIFF
--- a/pkg/utils/port.go
+++ b/pkg/utils/port.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 )
 
 // PortManager manages the allocation and deallocation of network ports.
@@ -27,12 +28,16 @@ func NewPortManager(startPort, maxPort, portIncrement int) *PortManager {
 // IsPortAvailable checks if a port is available for use.
 func (pm *PortManager) IsPortAvailable(port int) bool {
 	address := fmt.Sprintf("127.0.0.1:%d", port)
-	ln, err := net.Listen("tcp", address)
-	if err != nil {
+
+	// Attempt to connect to the port
+	conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+
+	// If connection is successful, close it and return false (port is not available)
+	if err == nil {
+		conn.Close()
 		return false
 	}
 
-	ln.Close()
 	return true
 }
 


### PR DESCRIPTION
Using `Listen` would not always work on MacOS for some reason even if the container was already running on that port, `Listen` was able to allocate that port for itself. 
This PR fixes that by using `DialTimeout`. It allows checking port availability from a client's perspective by attempting a connection with a specific timeout, useful for validating remote service accessibility without needing to bind to the port itself.